### PR TITLE
Add docker helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ $ tlmgr update --self
 $ tlmgr install fancyhdr caption subcaption nicefrac microtype lipsum graphics natbib doi
 ```
 
+### Docker
+
+You can build and run Causal-Copilot inside a Docker container. A helper script
+`build_and_run_docker.sh` is provided at the project root:
+
+```bash
+./build_and_run_docker.sh cpu  # or gpu
+```
+
 ---
 
 ## Usage

--- a/build_and_run_docker.sh
+++ b/build_and_run_docker.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build and run the Causal-Copilot Docker container.
+# Usage: ./build_and_run_docker.sh [cpu|gpu]
+
+set -e
+
+DEVICE=${1:-cpu}
+IMAGE="causal-copilot:${DEVICE}"
+
+if [[ "$DEVICE" == "gpu" ]]; then
+    DOCKERFILE="Dockerfile.gpu"
+    GPU_FLAG="--gpus all"
+else
+    DOCKERFILE="Dockerfile.cpu"
+    GPU_FLAG=""
+fi
+
+echo "Building $IMAGE using $DOCKERFILE ..."
+docker build -t "$IMAGE" -f "$DOCKERFILE" .
+
+echo "Running $IMAGE ..."
+docker run --rm -it $GPU_FLAG -v "$(pwd)":/app "$IMAGE"


### PR DESCRIPTION
## Summary
- add `build_and_run_docker.sh` to build/run images for CPU or GPU
- document docker usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tqdm')*

------
https://chatgpt.com/codex/tasks/task_e_6881300f68808330904ac8c25c913547